### PR TITLE
Query tpr files with a data extraction function

### DIFF
--- a/scrap_zenodo.py
+++ b/scrap_zenodo.py
@@ -19,13 +19,15 @@ print(ZENODO_TOKEN)
 r = requests.get('https://zenodo.org/api/deposit/depositions',
                  params={'access_token': ZENODO_TOKEN})
 print(f"Status code:{r.status_code}")
+
+
 # Status code should be 200
 
 
 def search_zenodo(page=1, hits_per_page=10, year=2016):
     response = requests.get("https://zenodo.org/api/records",
                             params={"q": ("(title:(+molecular +dynamics) OR description:(+molecular +dynamics)')"
-                                         f" AND publication_date:[{year}-01-01 TO {year}-12-31]"
+                                          f" AND publication_date:[{year}-01-01 TO {year}-12-31]"
                                           " AND access_right:open"),
                                     "type": "dataset",
                                     "size": hits_per_page,
@@ -35,9 +37,9 @@ def search_zenodo(page=1, hits_per_page=10, year=2016):
     return response.json()
 
 
-#resp_json = search_zenodo(hits_per_page=100, year=2017)
-#total_hits = resp_json["hits"]["total"]
-#print(f'Number of hits: {total_hits}')
+# resp_json = search_zenodo(hits_per_page=100, year=2017)
+# total_hits = resp_json["hits"]["total"]
+# print(f'Number of hits: {total_hits}')
 
 
 # Record example
@@ -45,11 +47,7 @@ def search_zenodo(page=1, hits_per_page=10, year=2016):
 response = requests.get("https://zenodo.org/api/records/53887",
                         params={"access_token": ZENODO_TOKEN})
 resp_json = response.json()
-#print(resp_json)
-
-
-# Query:
-# resource_type.type:"dataset" AND filetype:"tpr"
+# print(resp_json)
 
 
 def extract_records(response_json):
@@ -90,7 +88,7 @@ def extract_records(response_json):
                          "title": record["title"],
                          "date_creation": record["date_creation"],
                          "date_last_modified": record["date_last_modified"],
-                         "author" : record["author"],
+                         "author": record["author"],
                          "keywords": record["keywords"],
                          "file_number": record["file_number"],
                          "download_number": record["download_number"],
@@ -113,8 +111,8 @@ max_hits_per_page = 100
 for year in range(2010, 2022):
     resp_json = search_zenodo(hits_per_page=1, year=year)
     total_hits = resp_json["hits"]["total"]
-    page_max = total_hits//max_hits_per_page + 1
-    for page in range(1, page_max+1):
+    page_max = total_hits // max_hits_per_page + 1
+    for page in range(1, page_max + 1):
         resp_json = search_zenodo(page=page, hits_per_page=max_hits_per_page, year=year)
         records_tmp, files_tmp = extract_records(resp_json)
         zenodo_records += records_tmp
@@ -125,7 +123,7 @@ for year in range(2010, 2022):
             break
 
 print(resp_json)
-print(f"Number of Zenodo records found: {len(zenodo_records)}")
+print(f"Number of Zenodo datasets found: {len(zenodo_records)}")
 print(f"Number of files found: {len(zenodo_files)}")
 
 records_df = pd.DataFrame(zenodo_records).set_index("dataset_id")
@@ -135,3 +133,10 @@ print(records_df.shape)
 files_df = pd.DataFrame(zenodo_files).set_index("dataset_id")
 files_df.to_csv("files.csv")
 print(files_df.shape)
+
+# Query:
+# resource_type.type:"dataset" AND filetype:"tpr"
+
+interest_df = files_df[files_df["file_type"].isin(["tpr"])]
+print(interest_df.shape)
+

--- a/scrap_zenodo.py
+++ b/scrap_zenodo.py
@@ -8,7 +8,7 @@ import pandas as pd
 
 def read_zenodo_token():
     """Read file Zenodo token from disk."""
-    dotenv.load_dotenv(".env.txt")
+    dotenv.load_dotenv(".env")
     return os.environ.get("ZENODO_TOKEN", "default")
 
 
@@ -57,11 +57,11 @@ resp_json = response.json()
 # Query: resource_type.type:"dataset" AND filetype:"tpr"
 # on the Zenodo website, we find 483 datasets.
 
-def search_tpr_zenodo(page=1, hits_per_page=10, year=2016):
+def search_zenodo_by_filetype(filetype, page=1, hits_per_page=10):
     """Search for datasets containing tpr files.
     """
     response = requests.get("https://zenodo.org/api/records",
-                            params={"q": 'resource_type.type:"dataset" AND filetype:"tpr"',
+                            params={"q": f'resource_type.type:"dataset" AND filetype:"{filetype}"',
                                     "type": "dataset",
                                     "size": hits_per_page,
                                     "page": page,
@@ -129,11 +129,11 @@ zenodo_files = []
 max_hits_per_record = 10_000
 max_hits_per_page = 100
 for year in range(2010, 2022):
-    resp_json = search_tpr_zenodo(hits_per_page=1, year=year)
+    resp_json = search_zenodo_by_filetype(hits_per_page=1, filetype="tpr")
     total_hits = resp_json["hits"]["total"]
     page_max = total_hits // max_hits_per_page + 1
     for page in range(1, page_max + 1):
-        resp_json = search_tpr_zenodo(page=page, hits_per_page=max_hits_per_page, year=year)
+        resp_json = search_zenodo_by_filetype(page=page, hits_per_page=max_hits_per_page, filetype="tpr")
         records_tmp, files_tmp = extract_records(resp_json)
         zenodo_records += records_tmp
         zenodo_files += files_tmp

--- a/scrap_zenodo.py
+++ b/scrap_zenodo.py
@@ -46,9 +46,7 @@ response = requests.get("https://zenodo.org/api/records/53887",
                         params={"access_token": ZENODO_TOKEN})
 resp_json = response.json()
 #print(resp_json)
-#print(resp_json["metadata"]["keywords"])
-#print(' ; '.join([str(elem) for elem in resp_json["metadata"]["keywords"]]))
-#print(resp_json["metadata"]["creators"][0]["name"])
+
 
 # Query:
 # resource_type.type:"dataset" AND filetype:"tpr"
@@ -86,10 +84,24 @@ def extract_records(response_json):
         record["license"] = hit["metadata"]["license"]["id"]
         records.append(record)
         for file_in in hit["files"]:
-            file_dict = {"record_id": record["dataset_id"],
-                            "name": file_in["key"],
-                            "type": file_in["type"],
-                            "size": file_in["size"]}
+            file_dict = {"dataset_id": record["dataset_id"],
+                         "origin": record["origin"],
+                         "doi": record["doi"],
+                         "title": record["title"],
+                         "date_creation": record["date_creation"],
+                         "date_last_modified": record["date_last_modified"],
+                         "author" : record["author"],
+                         "keywords": record["keywords"],
+                         "file_number": record["file_number"],
+                         "download_number": record["download_number"],
+                         "view_number": record["view_number"],
+                         "license": record["license"],
+                         "file_name": file_in["key"],
+                         "file_extension": file_in["type"],
+                         "file_size": file_in["size"],
+                         "file_url": file_in["links"],
+                         "file_md5": file_in["checksum"],
+                         "file_type": file_in["type"]}
             files.append(file_dict)
     return records, files
 
@@ -119,3 +131,7 @@ print(f"Number of files found: {len(zenodo_files)}")
 records_df = pd.DataFrame(zenodo_records).set_index("dataset_id")
 records_df.to_csv("datasets.csv")
 print(records_df.shape)
+
+files_df = pd.DataFrame(zenodo_files).set_index("dataset_id")
+files_df.to_csv("files.csv")
+print(files_df.shape)


### PR DESCRIPTION
Hello @pierrepo,

I made the query "resource_type.type: "dataset" AND filetype: "tpr"" by 
- create the search_tpr_zenodo function to find the tpr files
- add function extract_records following data_model.csv to collect the data

As a result, we find 473 datasets containing tpr files. If we make the query directly in the Zenodo web interface, we have 483 datasets.
