### PR TITLE
Added tng format

### DIFF
--- a/params/query.yml
+++ b/params/query.yml
@@ -62,6 +62,10 @@ file_types:
   engine: gromacs
   keywords: none
   category: trajectory
+- type: tng
+  engine: gromacs
+  keywords: none
+  category: trajectory
 - type: cpt
   engine: gromacs
   keywords: none


### PR DESCRIPTION
See [https://manual.gromacs.org/current/manual-2022.1.pdf], page 26:
```
Trajectory file (.trr, .tng, or .xtc)
```