### PR TITLE
fix(pydantic): use model_validate() for metadata validation (#54)

### DIFF
--- a/src/mdverse_scrapers/models/utils.py
+++ b/src/mdverse_scrapers/models/utils.py
@@ -29,7 +29,7 @@ def validate_metadata_against_model(
         Validated model instance or None if validation fails.
     """
     try:
-        return model(**metadata)
+        return model.model_validate(metadata)
     except ValidationError as exc:
         logger.warning("Validation error!")
         for error in exc.errors():


### PR DESCRIPTION
This PR addresses issue #54 by replacing `model(**metadata)` with `model.model_validate(metadata)`  for proper Pydantic v2 validation. 