### PR TITLE
refactor(pydantic): forbid extra fields in all data models

### DIFF
--- a/src/mdverse_scrapers/models/dataset.py
+++ b/src/mdverse_scrapers/models/dataset.py
@@ -5,6 +5,7 @@ from typing import Annotated
 
 from pydantic import (
     BaseModel,
+    ConfigDict,
     Field,
     StringConstraints,
     field_validator,
@@ -30,6 +31,9 @@ class DatasetCoreMetadata(BaseModel):
 
     This model captures essential information about the source repository
     """
+
+    # Ensure scraped metadata matches the expected schema exactly.
+    model_config = ConfigDict(extra="forbid")
 
     dataset_repository_name: DatasetSourceName = Field(
         ...,
@@ -58,6 +62,9 @@ class DatasetMetadata(SimulationMetadata, DatasetCoreMetadata):
 
     This model extends DatasetCoreMetadata with dataset-specific metadata.
     """
+
+    # Ensure scraped metadata matches the expected schema exactly.
+    model_config = ConfigDict(extra="forbid")
 
     # ------------------------------------------------------------------
     # Project metadata

--- a/src/mdverse_scrapers/models/file.py
+++ b/src/mdverse_scrapers/models/file.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 
-from pydantic import ByteSize, Field, computed_field, field_validator
+from pydantic import ByteSize, ConfigDict, Field, computed_field, field_validator
 
 from .dataset import DatasetCoreMetadata
 
@@ -17,6 +17,9 @@ class FileMetadata(DatasetCoreMetadata):
     This model inherits core provenance information from DatasetCoreMetadata
     and defines file-specific metadata such as file name, extension...
     """
+
+    # Ensure scraped metadata matches the expected schema exactly.
+    model_config = ConfigDict(extra="forbid")
 
     # ------------------------------------------------------------------
     # Descriptive metadata

--- a/src/mdverse_scrapers/models/scraper.py
+++ b/src/mdverse_scrapers/models/scraper.py
@@ -4,7 +4,14 @@ from datetime import datetime
 from pathlib import Path
 from typing import Self
 
-from pydantic import BaseModel, DirectoryPath, Field, FilePath, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    DirectoryPath,
+    Field,
+    FilePath,
+    model_validator,
+)
 
 from .enums import DatasetSourceName, DataType
 
@@ -14,6 +21,9 @@ class ScraperContext(BaseModel):
 
     Mandatory fields are `data_source_name` and `output_dir_path`.
     """
+
+    # Ensure scraped metadata matches the expected schema exactly.
+    model_config = ConfigDict(extra="forbid")
 
     data_source_name: DatasetSourceName = Field(
         ...,

--- a/src/mdverse_scrapers/models/simulation.py
+++ b/src/mdverse_scrapers/models/simulation.py
@@ -3,7 +3,7 @@
 import re
 from typing import Annotated
 
-from pydantic import BaseModel, Field, StringConstraints, field_validator
+from pydantic import BaseModel, ConfigDict, Field, StringConstraints, field_validator
 
 DOI = Annotated[
     str,
@@ -13,6 +13,9 @@ DOI = Annotated[
 
 class Molecule(BaseModel):
     """Molecule in a simulation."""
+
+    # Ensure scraped metadata matches the expected schema exactly.
+    model_config = ConfigDict(extra="forbid")
 
     name: str = Field(..., description="Name of the molecule.")
     number_of_atoms: int | None = Field(
@@ -26,6 +29,9 @@ class Molecule(BaseModel):
 class ForceFieldModel(BaseModel):
     """Forcefield or Model used in a simulation."""
 
+    # Ensure scraped metadata matches the expected schema exactly.
+    model_config = ConfigDict(extra="forbid")
+
     name: str = Field(
         ...,
         description=(
@@ -37,6 +43,9 @@ class ForceFieldModel(BaseModel):
 
 class Software(BaseModel):
     """Simulation software or tool used in a simulation."""
+
+    # Ensure scraped metadata matches the expected schema exactly.
+    model_config = ConfigDict(extra="forbid")
 
     name: str = Field(
         ...,
@@ -53,6 +62,9 @@ class SimulationMetadata(BaseModel):
 
     No field is required in this model; all are optional.
     """
+
+    # Ensure scraped metadata matches the expected schema exactly.
+    model_config = ConfigDict(extra="forbid")
 
     software: list[Software] | None = Field(
         None,


### PR DESCRIPTION
This pull request enforces strict schema validation across all Pydantic models in the codebase by configuring each model to forbid extra fields that are not explicitly defined in the schema. This ensures that any metadata or data passed to these models must exactly match the expected structure, improving data integrity and catching potential errors early.

**Schema validation enforcement:**

* Added `model_config = ConfigDict(extra="forbid")` to all key Pydantic models (`DatasetCoreMetadata`, `DatasetMetadata`, `FileMetadata`, `ScraperContext`, `Molecule`, `ForceFieldModel`, `Software`, and `SimulationMetadata`) to strictly enforce that only explicitly defined fields are allowed. [[1]](diffhunk://#diff-efb1ab7380597c47fac50f03d0bd2b349e5e195b29d6225799b4796a24d64184R35-R37) [[2]](diffhunk://#diff-efb1ab7380597c47fac50f03d0bd2b349e5e195b29d6225799b4796a24d64184R66-R68) [[3]](diffhunk://#diff-4259b08fa5cd03ea336fddfead7a82b056068b296acdac01cfa4d06429fb6ad1R21-R23) [[4]](diffhunk://#diff-8f9a0c00061b128e48e02787eb6adb1906cd4c03f60742534b49695de4678180R25-R27) [[5]](diffhunk://#diff-401daee7eb52189404f089da2495ff5d88e5b1f9fba100f80569ceb6b27e5f6cR17-R19) [[6]](diffhunk://#diff-401daee7eb52189404f089da2495ff5d88e5b1f9fba100f80569ceb6b27e5f6cR32-R34) [[7]](diffhunk://#diff-401daee7eb52189404f089da2495ff5d88e5b1f9fba100f80569ceb6b27e5f6cR47-R49) [[8]](diffhunk://#diff-401daee7eb52189404f089da2495ff5d88e5b1f9fba100f80569ceb6b27e5f6cR66-R68)

**Imports update:**

* Updated imports in all affected files to include `ConfigDict` from Pydantic, enabling the new model configuration. [[1]](diffhunk://#diff-efb1ab7380597c47fac50f03d0bd2b349e5e195b29d6225799b4796a24d64184R8) [[2]](diffhunk://#diff-4259b08fa5cd03ea336fddfead7a82b056068b296acdac01cfa4d06429fb6ad1L5-R5) [[3]](diffhunk://#diff-8f9a0c00061b128e48e02787eb6adb1906cd4c03f60742534b49695de4678180L7-R14) [[4]](diffhunk://#diff-401daee7eb52189404f089da2495ff5d88e5b1f9fba100f80569ceb6b27e5f6cL6-R6)